### PR TITLE
feat: add InfraHouseGovernance cross-account role

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -18,15 +18,18 @@ skip-check:
   # Same as CKV_TF_1 - Renovate handles module version updates.
   - CKV_TF_2
 
-  # CKV_AWS_111: InfraHouseLogRetention policy uses "*" resource for write-without-constraints actions.
-  # This role enforces log retention and tags Control Tower-managed log groups (for Vanta exclusion)
-  # across ALL log groups in the account. Scoping to specific log group ARNs would defeat the purpose.
+  # CKV_AWS_111: InfraHouseLogRetention and InfraHouseGovernance policies use "*" resource for
+  # write-without-constraints actions. These roles enforce log retention and tag Control Tower-managed
+  # log groups (for Vanta exclusion) across ALL log groups in the account; InfraHouseGovernance
+  # additionally tags Control Tower-managed Lambda functions with VantaNoAlert=true across ALL functions.
+  # Scoping to specific resource ARNs would defeat the purpose.
   - CKV_AWS_111
 
-  # CKV_AWS_356: InfraHouseLogRetention policy uses "*" resource for restrictable actions.
-  # logs:DescribeLogGroups, logs:PutRetentionPolicy, logs:ListTagsForResource, logs:TagResource,
-  # and logs:UntagResource must operate on all log groups to enforce retention and tagging org-wide.
-  # Note: logs:DescribeLogGroups does not support resource-level permissions at all.
+  # CKV_AWS_356: InfraHouseLogRetention and InfraHouseGovernance policies use "*" resource for
+  # restrictable actions. logs:DescribeLogGroups, logs:PutRetentionPolicy, logs:ListTagsForResource,
+  # logs:TagResource, logs:UntagResource, lambda:ListFunctions, lambda:ListTags, and lambda:TagResource
+  # must operate on all log groups / functions to enforce retention and tagging org-wide.
+  # Note: logs:DescribeLogGroups and lambda:ListFunctions do not support resource-level permissions at all.
   - CKV_AWS_356
 
   # CKV_AWS_9: Password expiration is no longer recommended by NIST SP 800-63B

--- a/README.md
+++ b/README.md
@@ -148,13 +148,17 @@ No modules.
 | [aws_guardduty_detector_feature.runtime_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector_feature) | resource |
 | [aws_iam_account_password_policy.strict](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_policy.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.InfraHouseGovernance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.InfraHouseLogRetention](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.InfraHouseGovernance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.InfraHouseLogRetention](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_account_public_access_block.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_sns_topic.guardduty_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_subscription.guardduty_emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_iam_policy_document.InfraHouseGovernance-permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.InfraHouseGovernance-trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.InfraHouseLogRetention-permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.InfraHouseLogRetention-trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guardduty_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -173,5 +177,10 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_governance_role_arn"></a> [governance\_role\_arn](#output\_governance\_role\_arn) | ARN of the InfraHouseGovernance cross-account IAM role. |
+| <a name="output_governance_role_name"></a> [governance\_role\_name](#output\_governance\_role\_name) | Name of the InfraHouseGovernance cross-account IAM role. |
+| <a name="output_log_retention_role_arn"></a> [log\_retention\_role\_arn](#output\_log\_retention\_role\_arn) | ARN of the deprecated InfraHouseLogRetention cross-account IAM role.<br/>Kept for migration to InfraHouseGovernance; will be removed in the next<br/>major release. |
+| <a name="output_log_retention_role_name"></a> [log\_retention\_role\_name](#output\_log\_retention\_role\_name) | Name of the deprecated InfraHouseLogRetention cross-account IAM role.<br/>Kept for migration to InfraHouseGovernance; will be removed in the next<br/>major release. |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ controls in a single deployment:
 - **EBS Encryption**: Enables encryption by default for all EBS volumes in every region
 - **S3 Public Access Block**: Prevents public access to S3 buckets at the account level
 - **VPC Security**: Configures default security groups to deny all traffic
-- **Log Retention Role**: Creates a least-privilege IAM role for cross-account
-  CloudWatch log retention enforcement and log-group tagging (e.g. Vanta
-  exclusion of Control Tower-managed groups)
+- **Governance Role**: Creates a least-privilege IAM role
+  (`InfraHouseGovernance`) for cross-account CloudWatch log retention
+  enforcement, log-group tagging, and Lambda-function tagging (e.g. Vanta
+  exclusion of Control Tower-managed resources). The legacy
+  `InfraHouseLogRetention` role is also deployed and is **deprecated** —
+  it will be removed in the next major release. See
+  [issue #29](https://github.com/infrahouse/terraform-aws-iso27001/issues/29)
+  for the migration plan.
 
 ## Quick Start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,8 @@ These are account-level and apply regardless of region:
 | `aws_account_alternate_contact` | Security contact |
 | `aws_iam_account_password_policy` | IAM password policy |
 | `aws_s3_account_public_access_block` | Block public S3 access |
-| `aws_iam_role` (InfraHouseLogRetention) | Cross-account log retention |
+| `aws_iam_role` (InfraHouseGovernance) | Cross-account governance (log retention + Lambda tagging) |
+| `aws_iam_role` (InfraHouseLogRetention) | Cross-account log retention (**deprecated** — superseded by InfraHouseGovernance) |
 | `aws_iam_role` (guardduty-publish) | EventBridge to SNS for GuardDuty |
 
 ### Regional Resources (created per region)
@@ -47,19 +48,38 @@ resource "aws_ebs_encryption_by_default" "this" {
 }
 ```
 
-## Cross-Account Log Retention
+## Cross-Account Governance Roles
 
-The `InfraHouseLogRetention` IAM role is designed for use with
+This module deploys two cross-account IAM roles intended for use with
 [terraform-aws-org-governance](https://github.com/infrahouse/terraform-aws-org-governance).
-The trust policy allows the management account root to assume it. The
-permissions are scoped to `logs:DescribeLogGroups`,
-`logs:PutRetentionPolicy`, `logs:ListTagsForResource`, `logs:TagResource`,
-and `logs:UntagResource` only — enough to enforce retention policies and to
-tag Control Tower-managed log groups (e.g. for Vanta exclusion) without
-granting read access to log events. The tagging permissions exist because
+Both trust the management account root.
+
+### `InfraHouseGovernance` (current)
+
+Scoped to the broader set of read+tag operations the org-governance Lambda
+needs. Permissions:
+
+- `logs:DescribeLogGroups`, `logs:PutRetentionPolicy`,
+  `logs:ListTagsForResource`, `logs:TagResource`, `logs:UntagResource` —
+  enforce retention policies and tag Control Tower-managed log groups
+  (e.g. for Vanta exclusion) without granting read access to log events.
+- `lambda:ListFunctions`, `lambda:ListTags`, `lambda:TagResource` — tag
+  Control Tower-managed Lambda functions with `VantaNoAlert=true` to mark
+  them out of scope for Vanta's inventory checks.
+
 Control Tower-managed log groups are blocked from retention changes by the
 `GRLOGGROUPPOLICY` SCP, so the org-governance Lambda tags them with
-`VantaNoAlert=true` to mark them out of scope for Vanta's retention test.
+`VantaNoAlert=true` instead. The same pattern applies to Control
+Tower-managed Lambda functions.
+
+### `InfraHouseLogRetention` (deprecated)
+
+Original log-retention-only role, kept in place during the migration to
+`InfraHouseGovernance`. Both roles are deployed together for one release
+cycle; `InfraHouseLogRetention` will be removed in the next major release.
+See
+[issue #29](https://github.com/infrahouse/terraform-aws-iso27001/issues/29)
+for the deprecation timeline and rationale.
 
 ![Cross-Account Log Retention](assets/cross-account-log-retention.svg)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,4 +72,5 @@ guardduty_log_retention_days = 365
 | GuardDuty | Per region | All features enabled including runtime monitoring |
 | GuardDuty malware-scan log retention | Per region | 365-day retention on `/aws/guardduty/malware-scan-events` |
 | Default security groups | Per region | Deny all ingress and egress |
-| InfraHouseLogRetention role | Account | Trusts management account root |
+| InfraHouseGovernance role | Account | Trusts management account root; logs + lambda read/tag actions |
+| InfraHouseLogRetention role | Account | Trusts management account root (**deprecated**, removed in next major release) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,12 @@ confirmation from each region. Confirm it to receive GuardDuty findings.
 ## Multi-Account Setup
 
 In an AWS Organization, deploy this module in each member account. The module
-creates an `InfraHouseLogRetention` IAM role that trusts the management account,
-enabling centralized log retention enforcement via
+creates an `InfraHouseGovernance` IAM role that trusts the management account,
+enabling centralized log retention enforcement and Vanta-exclusion tagging of
+Control Tower-managed log groups and Lambda functions via
 [terraform-aws-org-governance](https://github.com/infrahouse/terraform-aws-org-governance).
+The legacy `InfraHouseLogRetention` role is also deployed for one release
+cycle to support migration; it is deprecated and will be removed in the next
+major release. See
+[issue #29](https://github.com/infrahouse/terraform-aws-iso27001/issues/29)
+for the migration plan.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,13 @@ controls without requiring provider aliases.
 - **EBS Encryption** -- encryption by default for all EBS volumes, per region
 - **S3 Public Access Block** -- prevents public access at the account level
 - **VPC Security** -- default security groups deny all traffic
-- **Log Retention Role** -- least-privilege IAM role for cross-account
-  CloudWatch log retention enforcement
+- **Governance Role** -- least-privilege `InfraHouseGovernance` IAM role
+  for cross-account CloudWatch log retention enforcement, log-group tagging,
+  and Lambda-function tagging (e.g. Vanta exclusion of Control Tower-managed
+  resources). The legacy `InfraHouseLogRetention` role is also deployed and
+  is **deprecated** -- it will be removed in the next major release. See
+  [issue #29](https://github.com/infrahouse/terraform-aws-iso27001/issues/29)
+  for the migration plan.
 
 ## Quick Start
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,8 +45,9 @@ Error: reading AWS Organization: AccessDeniedException
 ```
 
 The module calls `data.aws_organizations_organization` to discover the
-management account ID (used for the InfraHouseLogRetention trust policy).
-The calling role needs `organizations:DescribeOrganization` permission.
+management account ID (used for the InfraHouseGovernance and
+InfraHouseLogRetention trust policies). The calling role needs
+`organizations:DescribeOrganization` permission.
 
 ### SNS subscription not confirmed
 

--- a/iam-governance.tf
+++ b/iam-governance.tf
@@ -1,0 +1,51 @@
+# InfraHouseGovernance is assumed cross-account by the terraform-aws-org-governance
+# Lambda and covers the broader set of read+tag operations that module needs
+# (currently log-group retention/tagging plus tagging Control Tower-managed
+# Lambda functions with VantaNoAlert=true). It supersedes InfraHouseLogRetention
+# (see iam-log-retention.tf), which will be removed in the next major release.
+data "aws_iam_policy_document" "InfraHouseGovernance-trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["arn:aws:iam::${data.aws_organizations_organization.current.master_account_id}:root"]
+      type        = "AWS"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "InfraHouseGovernance-permissions" {
+  # Resource = "*" because this role operates on every log group and every
+  # Lambda function in the account. logs:DescribeLogGroups and
+  # lambda:ListFunctions do not support resource-level permissions; the
+  # remaining actions cover only resource ARNs in this account by definition.
+  # See .checkov.yml for CKV_AWS_111 / CKV_AWS_356 suppressions.
+  statement {
+    actions = [
+      "logs:DescribeLogGroups",
+      "logs:ListTagsForResource",
+      "logs:PutRetentionPolicy",
+      "logs:TagResource",
+      "logs:UntagResource",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "lambda:ListFunctions",
+      "lambda:ListTags",
+      "lambda:TagResource",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "InfraHouseGovernance" {
+  name               = "InfraHouseGovernance"
+  assume_role_policy = data.aws_iam_policy_document.InfraHouseGovernance-trust.json
+}
+
+resource "aws_iam_role_policy" "InfraHouseGovernance" {
+  name   = "InfraHouseGovernance"
+  role   = aws_iam_role.InfraHouseGovernance.name
+  policy = data.aws_iam_policy_document.InfraHouseGovernance-permissions.json
+}

--- a/iam-log-retention.tf
+++ b/iam-log-retention.tf
@@ -1,3 +1,7 @@
+# DEPRECATED: InfraHouseLogRetention is superseded by InfraHouseGovernance
+# (see iam-governance.tf) and will be removed in the next major release of
+# this module. See https://github.com/infrahouse/terraform-aws-iso27001/issues/29
+# for the migration plan.
 data "aws_iam_policy_document" "InfraHouseLogRetention-trust" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,27 @@
+output "governance_role_name" {
+  description = "Name of the InfraHouseGovernance cross-account IAM role."
+  value       = aws_iam_role.InfraHouseGovernance.name
+}
+
+output "governance_role_arn" {
+  description = "ARN of the InfraHouseGovernance cross-account IAM role."
+  value       = aws_iam_role.InfraHouseGovernance.arn
+}
+
+output "log_retention_role_name" {
+  description = <<-EOT
+    Name of the deprecated InfraHouseLogRetention cross-account IAM role.
+    Kept for migration to InfraHouseGovernance; will be removed in the next
+    major release.
+  EOT
+  value       = aws_iam_role.InfraHouseLogRetention.name
+}
+
+output "log_retention_role_arn" {
+  description = <<-EOT
+    ARN of the deprecated InfraHouseLogRetention cross-account IAM role.
+    Kept for migration to InfraHouseGovernance; will be removed in the next
+    major release.
+  EOT
+  value       = aws_iam_role.InfraHouseLogRetention.arn
+}

--- a/test_data/iso27001/main.tf
+++ b/test_data/iso27001/main.tf
@@ -20,3 +20,19 @@ module "iso27001" {
     phone_number = "+1234567890"
   }
 }
+
+output "governance_role_name" {
+  value = module.iso27001.governance_role_name
+}
+
+output "governance_role_arn" {
+  value = module.iso27001.governance_role_arn
+}
+
+output "log_retention_role_name" {
+  value = module.iso27001.log_retention_role_name
+}
+
+output "log_retention_role_arn" {
+  value = module.iso27001.log_retention_role_arn
+}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -11,6 +11,19 @@ from tests.conftest import (
     TERRAFORM_ROOT_DIR,
 )
 
+GOVERNANCE_LOGS_ACTIONS = {
+    "logs:DescribeLogGroups",
+    "logs:ListTagsForResource",
+    "logs:PutRetentionPolicy",
+    "logs:TagResource",
+    "logs:UntagResource",
+}
+GOVERNANCE_LAMBDA_ACTIONS = {
+    "lambda:ListFunctions",
+    "lambda:ListTags",
+    "lambda:TagResource",
+}
+
 
 @pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
 def test_module(
@@ -18,6 +31,7 @@ def test_module(
     keep_after,
     aws_region,
     aws_provider_version,
+    iam_client,
 ):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "iso27001")
     state_files = [
@@ -64,3 +78,54 @@ def test_module(
         json_output=True,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
+
+        governance_role_name = tf_output["governance_role_name"]["value"]
+        log_retention_role_name = tf_output["log_retention_role_name"]["value"]
+        assert governance_role_name == "InfraHouseGovernance"
+        assert log_retention_role_name == "InfraHouseLogRetention"
+
+        _assert_role_trusts_master_account(iam_client, governance_role_name)
+        _assert_role_trusts_master_account(iam_client, log_retention_role_name)
+
+        governance_actions = _collect_inline_policy_actions(
+            iam_client, governance_role_name, governance_role_name
+        )
+        assert GOVERNANCE_LOGS_ACTIONS.issubset(governance_actions)
+        assert GOVERNANCE_LAMBDA_ACTIONS.issubset(governance_actions)
+
+        log_retention_actions = _collect_inline_policy_actions(
+            iam_client, log_retention_role_name, log_retention_role_name
+        )
+        assert GOVERNANCE_LOGS_ACTIONS.issubset(log_retention_actions)
+        assert log_retention_actions.isdisjoint(GOVERNANCE_LAMBDA_ACTIONS)
+
+
+def _assert_role_trusts_master_account(iam_client, role_name):
+    role = iam_client.get_role(RoleName=role_name)["Role"]
+    statements = role["AssumeRolePolicyDocument"]["Statement"]
+    principals = []
+    for statement in statements:
+        if statement.get("Effect", "Allow") != "Allow":
+            continue
+        if "sts:AssumeRole" not in _as_list(statement.get("Action", [])):
+            continue
+        principals.extend(_as_list(statement.get("Principal", {}).get("AWS", [])))
+    assert any(
+        p.endswith(":root") for p in principals
+    ), f"{role_name} trust policy does not allow an account root principal: {principals}"
+
+
+def _collect_inline_policy_actions(iam_client, role_name, policy_name):
+    policy = iam_client.get_role_policy(RoleName=role_name, PolicyName=policy_name)
+    actions = set()
+    for statement in policy["PolicyDocument"]["Statement"]:
+        if statement.get("Effect", "Allow") != "Allow":
+            continue
+        actions.update(_as_list(statement.get("Action", [])))
+    return actions
+
+
+def _as_list(value):
+    if isinstance(value, list):
+        return value
+    return [value]


### PR DESCRIPTION
## Summary

- Adds the `InfraHouseGovernance` IAM role as a net-additive successor to `InfraHouseLogRetention`. The new role keeps the existing `logs:*` permissions and adds `lambda:ListFunctions`, `lambda:ListTags`, `lambda:TagResource` for tagging Control Tower-managed Lambda functions with `VantaNoAlert=true` from the `terraform-aws-org-governance` Lambda.
- `InfraHouseLogRetention` is **deprecated** but unchanged in this release; it will be removed in the next major release once `terraform-aws-org-governance` has cut over. The two roles live in separate files (`iam-governance.tf`, `iam-log-retention.tf`) so the eventual deprecation PR is a clean delete.
- Adds module outputs (`governance_role_*`, `log_retention_role_*`) so consumers can pin to whichever role they need during migration. Updates `README.md` and `docs/architecture.md`, broadens the `CKV_AWS_111` / `CKV_AWS_356` justifications, and extends `tests/test_module.py` to assert both roles exist with valid trust policies and that only the new role grants the lambda actions.

Closes #29.

## Test plan

- [ ] `make test-clean` (real-AWS integration test asserts both roles, trust policies, and policy actions)
- [ ] `terraform fmt -check -recursive` (passing locally)
- [ ] `black --check tests/` (passing locally)
- [ ] CI vuln scan / security workflow green
- [ ] Verify terraform-docs auto-regenerates the README resource/output tables on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)