### PR TITLE
feat: add Vanta auditor IAM role with SSM-backed external ID

### DIFF
--- a/.claude/plans/vanta-role-automation.md
+++ b/.claude/plans/vanta-role-automation.md
@@ -1,0 +1,62 @@
+# Vanta Role Automation — iso27001 Changes
+
+## Context
+
+The management-account module (`terraform-aws-org-governance`) now
+distributes the Vanta external ID to all member accounts via a
+CloudFormation StackSet (SERVICE_MANAGED). The SSM parameter
+`/vanta/external_id` is guaranteed to exist in every member account
+before iso27001 is deployed — auto-deployment fires on OU membership
+during Control Tower enrollment, before any Terraform runs.
+
+Full plan lives in:
+`terraform-aws-org-governance/.claude/plans/vanta-role-automation.md`
+
+---
+
+## Work Items
+
+### 1. InfraHouseGovernance role — NO CHANGE NEEDED
+
+No SSM permissions required — the org-governance Lambda no longer
+writes SSM params. StackSets handles distribution via the
+Organizations service trust.
+
+### 2. Vanta role external ID from SSM — DONE
+
+Replace `var.vanta_external_id` with an SSM data source:
+
+```hcl
+data "aws_ssm_parameter" "vanta_external_id" {
+  name = "/vanta/external_id"
+}
+```
+
+Use `data.aws_ssm_parameter.vanta_external_id.value` in the trust
+policy. Remove `var.vanta_external_id` entirely — no fallback needed
+because the StackSet guarantees the parameter exists before iso27001
+is ever deployed.
+
+### 3. Identity Store permissions — SKIPPED (harmless, simpler)
+
+The current `vanta_additional_permissions` policy includes Identity
+Store actions. These only work in the management account (where IAM
+Identity Center lives). In member accounts they are harmless no-ops
+but add noise. Consider splitting or leave as-is (harmless, simpler).
+
+---
+
+## State Migration — delete-and-recreate
+
+The vanta-auditor role exists in AWS managed by github-control.
+No import needed — just delete from github-control first, then
+iso27001 creates it fresh. Brief Vanta scan gap is acceptable.
+
+## Deployment Order
+
+1. **terraform-aws-org-governance** deploys StackSet — SSM params
+   appear in all member accounts (already done).
+2. **github-control** removes `vanta.tf` and applies — deletes
+   the old role from all accounts.
+3. **terraform-aws-iso27001** releases and applies — creates the
+   role fresh with SSM-backed external ID.

--- a/README.md
+++ b/README.md
@@ -148,22 +148,30 @@ No modules.
 | [aws_guardduty_detector_feature.runtime_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector_feature) | resource |
 | [aws_iam_account_password_policy.strict](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_policy.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.vanta_additional_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.InfraHouseGovernance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.InfraHouseLogRetention](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.vanta_auditor](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.InfraHouseGovernance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.InfraHouseLogRetention](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.vanta_additional_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.vanta_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_account_public_access_block.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block) | resource |
 | [aws_sns_topic.guardduty_notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_subscription.guardduty_emails](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [aws_iam_policy.security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.InfraHouseGovernance-permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.InfraHouseGovernance-trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.InfraHouseLogRetention-permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.InfraHouseLogRetention-trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guardduty_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guardduty_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vanta_additional_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vanta_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+| [aws_ssm_parameter.vanta_external_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_vpcs.aws_control_tower_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpcs) | data source |
 
 ## Inputs
@@ -183,4 +191,6 @@ No modules.
 | <a name="output_governance_role_name"></a> [governance\_role\_name](#output\_governance\_role\_name) | Name of the InfraHouseGovernance cross-account IAM role. |
 | <a name="output_log_retention_role_arn"></a> [log\_retention\_role\_arn](#output\_log\_retention\_role\_arn) | ARN of the deprecated InfraHouseLogRetention cross-account IAM role.<br/>Kept for migration to InfraHouseGovernance; will be removed in the next<br/>major release. |
 | <a name="output_log_retention_role_name"></a> [log\_retention\_role\_name](#output\_log\_retention\_role\_name) | Name of the deprecated InfraHouseLogRetention cross-account IAM role.<br/>Kept for migration to InfraHouseGovernance; will be removed in the next<br/>major release. |
+| <a name="output_vanta_auditor_role_arn"></a> [vanta\_auditor\_role\_arn](#output\_vanta\_auditor\_role\_arn) | ARN of the Vanta auditor IAM role. |
+| <a name="output_vanta_auditor_role_name"></a> [vanta\_auditor\_role\_name](#output\_vanta\_auditor\_role\_name) | Name of the Vanta auditor IAM role. |
 <!-- END_TF_DOCS -->

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@ These are account-level and apply regardless of region:
 | `aws_account_alternate_contact` | Security contact |
 | `aws_iam_account_password_policy` | IAM password policy |
 | `aws_s3_account_public_access_block` | Block public S3 access |
+| `aws_iam_role` (vanta-auditor) | Vanta compliance scanner (SecurityAudit + Identity Store read) |
 | `aws_iam_role` (InfraHouseGovernance) | Cross-account governance (log retention + Lambda tagging) |
 | `aws_iam_role` (InfraHouseLogRetention) | Cross-account log retention (**deprecated** — superseded by InfraHouseGovernance) |
 | `aws_iam_role` (guardduty-publish) | EventBridge to SNS for GuardDuty |
@@ -47,6 +48,22 @@ resource "aws_ebs_encryption_by_default" "this" {
   region   = each.key
 }
 ```
+
+## Vanta Auditor Role
+
+The `vanta-auditor` IAM role allows Vanta's scanner
+(`arn:aws:iam::956993596390:role/scanner`) to audit the account. The trust
+policy requires an external ID read from SSM parameter `/vanta/external_id`,
+which is distributed to all member accounts by the org-governance StackSet.
+
+Attached policies:
+
+- **SecurityAudit** (AWS managed) — broad read-only access for compliance
+  scanning.
+- **VantaAdditionalPermissions** (custom) — Identity Store read actions
+  (`identitystore:Describe*`, `List*`, `Get*`, `IsMemberInGroups`) plus
+  explicit denies on `datapipeline:EvaluateExpression`,
+  `datapipeline:QueryObjects`, and `rds:DownloadDBLogFilePortion`.
 
 ## Cross-Account Governance Roles
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,5 +72,6 @@ guardduty_log_retention_days = 365
 | GuardDuty | Per region | All features enabled including runtime monitoring |
 | GuardDuty malware-scan log retention | Per region | 365-day retention on `/aws/guardduty/malware-scan-events` |
 | Default security groups | Per region | Deny all ingress and egress |
+| Vanta auditor role | Account | `vanta-auditor` role with SecurityAudit + Identity Store read; external ID from SSM |
 | InfraHouseGovernance role | Account | Trusts management account root; logs + lambda read/tag actions |
 | InfraHouseLogRetention role | Account | Trusts management account root (**deprecated**, removed in next major release) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,10 @@ controls without requiring provider aliases.
 - **EBS Encryption** -- encryption by default for all EBS volumes, per region
 - **S3 Public Access Block** -- prevents public access at the account level
 - **VPC Security** -- default security groups deny all traffic
+- **Vanta Auditor Role** -- `vanta-auditor` IAM role for Vanta's compliance
+  scanner, with `SecurityAudit` and Identity Store read permissions. The
+  external ID is read from SSM parameter `/vanta/external_id` (distributed
+  by the org-governance StackSet).
 - **Governance Role** -- least-privilege `InfraHouseGovernance` IAM role
   for cross-account CloudWatch log retention enforcement, log-group tagging,
   and Lambda-function tagging (e.g. Vanta exclusion of Control Tower-managed

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,16 @@ output "governance_role_arn" {
   value       = aws_iam_role.InfraHouseGovernance.arn
 }
 
+output "vanta_auditor_role_name" {
+  description = "Name of the Vanta auditor IAM role."
+  value       = aws_iam_role.vanta_auditor.name
+}
+
+output "vanta_auditor_role_arn" {
+  description = "ARN of the Vanta auditor IAM role."
+  value       = aws_iam_role.vanta_auditor.arn
+}
+
 output "log_retention_role_name" {
   description = <<-EOT
     Name of the deprecated InfraHouseLogRetention cross-account IAM role.

--- a/test_data/iso27001/main.tf
+++ b/test_data/iso27001/main.tf
@@ -1,13 +1,6 @@
-resource "aws_ssm_parameter" "vanta_external_id" {
-  name  = "/vanta/external_id"
-  type  = "SecureString"
-  value = "test-external-id"
-}
-
 module "iso27001" {
-  depends_on = [aws_ssm_parameter.vanta_external_id]
-  source     = "./../../"
-  regions    = var.regions
+  source  = "./../../"
+  regions = var.regions
   primary_contact = {
     address_line_1     = "123 Any Street"
     city               = "Seattle"

--- a/test_data/iso27001/main.tf
+++ b/test_data/iso27001/main.tf
@@ -1,6 +1,13 @@
+resource "aws_ssm_parameter" "vanta_external_id" {
+  name  = "/vanta/external_id"
+  type  = "SecureString"
+  value = "test-external-id"
+}
+
 module "iso27001" {
-  source  = "./../../"
-  regions = var.regions
+  depends_on = [aws_ssm_parameter.vanta_external_id]
+  source     = "./../../"
+  regions    = var.regions
   primary_contact = {
     address_line_1     = "123 Any Street"
     city               = "Seattle"
@@ -27,6 +34,14 @@ output "governance_role_name" {
 
 output "governance_role_arn" {
   value = module.iso27001.governance_role_arn
+}
+
+output "vanta_auditor_role_name" {
+  value = module.iso27001.vanta_auditor_role_name
+}
+
+output "vanta_auditor_role_arn" {
+  value = module.iso27001.vanta_auditor_role_arn
 }
 
 output "log_retention_role_name" {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 
+import pytest
 from infrahouse_core.logging import setup_logging
 
 DEFAULT_PROGRESS_INTERVAL = 10
@@ -10,3 +11,24 @@ LOG = logging.getLogger(__name__)
 
 
 setup_logging(LOG, debug=True)
+
+
+@pytest.fixture()
+def ssm_client(boto3_session, aws_region):
+    return boto3_session.client("ssm", region_name=aws_region)
+
+
+@pytest.fixture()
+def vanta_external_id(ssm_client):
+    param_name = "/vanta/external_id"
+    value = "test-external-id"
+    ssm_client.put_parameter(
+        Name=param_name,
+        Value=value,
+        Type="SecureString",
+        Overwrite=True,
+    )
+    try:
+        yield value
+    finally:
+        ssm_client.delete_parameter(Name=param_name)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -81,8 +81,10 @@ def test_module(
 
         governance_role_name = tf_output["governance_role_name"]["value"]
         log_retention_role_name = tf_output["log_retention_role_name"]["value"]
+        vanta_role_name = tf_output["vanta_auditor_role_name"]["value"]
         assert governance_role_name == "InfraHouseGovernance"
         assert log_retention_role_name == "InfraHouseLogRetention"
+        assert vanta_role_name == "vanta-auditor"
 
         _assert_role_trusts_master_account(iam_client, governance_role_name)
         _assert_role_trusts_master_account(iam_client, log_retention_role_name)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -32,6 +32,7 @@ def test_module(
     aws_region,
     aws_provider_version,
     iam_client,
+    vanta_external_id,
 ):
     terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "iso27001")
     state_files = [

--- a/vanta.tf
+++ b/vanta.tf
@@ -1,0 +1,79 @@
+data "aws_ssm_parameter" "vanta_external_id" {
+  name = "/vanta/external_id"
+}
+
+data "aws_iam_policy_document" "vanta_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::956993596390:role/scanner"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [data.aws_ssm_parameter.vanta_external_id.value]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "vanta_additional_permissions" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "identitystore:DescribeGroup",
+      "identitystore:DescribeGroupMembership",
+      "identitystore:DescribeUser",
+      "identitystore:GetGroupId",
+      "identitystore:GetGroupMembershipId",
+      "identitystore:GetUserId",
+      "identitystore:IsMemberInGroups",
+      "identitystore:ListGroupMemberships",
+      "identitystore:ListGroupMembershipsForMember",
+      "identitystore:ListGroups",
+      "identitystore:ListUsers",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Deny"
+    actions = [
+      "datapipeline:EvaluateExpression",
+      "datapipeline:QueryObjects",
+      "rds:DownloadDBLogFilePortion",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "vanta_auditor" {
+  name               = "vanta-auditor"
+  assume_role_policy = data.aws_iam_policy_document.vanta_assume_role.json
+
+  tags = local.default_module_tags
+}
+
+data "aws_iam_policy" "security_audit" {
+  name = "SecurityAudit"
+}
+
+resource "aws_iam_role_policy_attachment" "vanta_security_audit" {
+  role       = aws_iam_role.vanta_auditor.name
+  policy_arn = data.aws_iam_policy.security_audit.arn
+}
+
+resource "aws_iam_policy" "vanta_additional_permissions" {
+  name   = "VantaAdditionalPermissions"
+  policy = data.aws_iam_policy_document.vanta_additional_permissions.json
+
+  tags = local.default_module_tags
+}
+
+resource "aws_iam_role_policy_attachment" "vanta_additional_permissions" {
+  role       = aws_iam_role.vanta_auditor.name
+  policy_arn = aws_iam_policy.vanta_additional_permissions.arn
+}


### PR DESCRIPTION
## Summary

- Add `vanta-auditor` IAM role with `SecurityAudit` + Identity Store read permissions for Vanta's compliance scanner
- External ID sourced from SSM parameter `/vanta/external_id` (distributed by org-governance StackSet) — no module variable needed
- New outputs: `vanta_auditor_role_name` and `vanta_auditor_role_arn`
- Documentation updated (architecture, configuration, index)

## Deployment notes

The vanta-auditor role currently exists in AWS managed by github-control.
Deployment order:
1. org-governance StackSet distributes SSM params (already done)
2. github-control removes its `vanta.tf` and applies (deletes old role)
3. This module releases and applies (creates role fresh with SSM-backed external ID)

Brief Vanta scan gap between steps 2 and 3 is acceptable.

## Test plan

- [ ] `make validate` passes
- [ ] Verify `/vanta/external_id` SSM parameter exists in target account
- [ ] Apply in test account, confirm role created with correct trust policy
- [ ] Verify Vanta scanner can assume the role

🤖 Generated with [Claude Code](https://claude.com/claude-code)