### PR TITLE
fix: add s3:GetBucketTagging to InfraHouseGovernance role

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,8 @@ needs. Permissions:
 - `lambda:ListFunctions`, `lambda:ListTags`, `lambda:TagResource` — tag
   Control Tower-managed Lambda functions with `VantaNoAlert=true` to mark
   them out of scope for Vanta's inventory checks.
+- `s3:ListAllMyBuckets`, `s3:GetBucketTagging` — read S3 bucket tags for
+  the Vanta S3 CRR exemption reconciler.
 
 Control Tower-managed log groups are blocked from retention changes by the
 `GRLOGGROUPPOLICY` SCP, so the org-governance Lambda tags them with

--- a/iam-governance.tf
+++ b/iam-governance.tf
@@ -37,6 +37,13 @@ data "aws_iam_policy_document" "InfraHouseGovernance-permissions" {
     ]
     resources = ["*"]
   }
+  statement {
+    actions = [
+      "s3:GetBucketTagging",
+      "s3:ListAllMyBuckets",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_role" "InfraHouseGovernance" {

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -23,6 +23,10 @@ GOVERNANCE_LAMBDA_ACTIONS = {
     "lambda:ListTags",
     "lambda:TagResource",
 }
+GOVERNANCE_S3_ACTIONS = {
+    "s3:GetBucketTagging",
+    "s3:ListAllMyBuckets",
+}
 
 
 @pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
@@ -95,6 +99,7 @@ def test_module(
         )
         assert GOVERNANCE_LOGS_ACTIONS.issubset(governance_actions)
         assert GOVERNANCE_LAMBDA_ACTIONS.issubset(governance_actions)
+        assert GOVERNANCE_S3_ACTIONS.issubset(governance_actions)
 
         log_retention_actions = _collect_inline_policy_actions(
             iam_client, log_retention_role_name, log_retention_role_name


### PR DESCRIPTION
## Summary

- Add `s3:GetBucketTagging` and `s3:ListAllMyBuckets` to the `InfraHouseGovernance` IAM role
- Required by the Vanta S3 CRR exemption reconciler Lambda in `terraform-aws-org-governance`
- Test assertion added for the new S3 actions

Closes #32

## Test plan

- [ ] CI passes
- [ ] Verify org-governance Lambda can call `s3:GetBucketTagging` after applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)