### PR TITLE
feat: add s3-batch-replication IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ controls in a single deployment:
   it will be removed in the next major release. See
   [issue #29](https://github.com/infrahouse/terraform-aws-iso27001/issues/29)
   for the migration plan.
+- **S3 Batch Replication Role**: Creates an IAM role (`s3-batch-replication`)
+  trusted by `batchoperations.s3.amazonaws.com` for running S3 Batch
+  Replication jobs to backfill existing objects when Cross-Region Replication
+  is enabled on a bucket
 
 ## Quick Start
 
@@ -152,9 +156,11 @@ No modules.
 | [aws_iam_role.InfraHouseGovernance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.InfraHouseLogRetention](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.s3_batch_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.vanta_auditor](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.InfraHouseGovernance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.InfraHouseLogRetention](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.s3_batch_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.guardduty](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.vanta_additional_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.vanta_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -168,6 +174,8 @@ No modules.
 | [aws_iam_policy_document.InfraHouseLogRetention-trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guardduty_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.guardduty_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_batch_replication_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_batch_replication_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vanta_additional_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vanta_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_organizations_organization.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ These are account-level and apply regardless of region:
 | `aws_iam_role` (vanta-auditor) | Vanta compliance scanner (SecurityAudit + Identity Store read) |
 | `aws_iam_role` (InfraHouseGovernance) | Cross-account governance (log retention + Lambda tagging) |
 | `aws_iam_role` (InfraHouseLogRetention) | Cross-account log retention (**deprecated** — superseded by InfraHouseGovernance) |
+| `aws_iam_role` (s3-batch-replication) | S3 Batch Replication jobs (backfill existing objects for CRR) |
 | `aws_iam_role` (guardduty-publish) | EventBridge to SNS for GuardDuty |
 
 ### Regional Resources (created per region)
@@ -101,6 +102,44 @@ See
 for the deprecation timeline and rationale.
 
 ![Cross-Account Log Retention](assets/cross-account-log-retention.svg)
+
+## S3 Batch Replication Role
+
+When Cross-Region Replication (CRR) is enabled on a bucket that previously had
+no versioning, existing objects are not replicated automatically — they remain
+in `NONE` replication status. S3 Batch Replication is needed to backfill them.
+
+The module creates an `s3-batch-replication` IAM role trusted by
+`batchoperations.s3.amazonaws.com` with the minimum permissions required:
+
+- `s3:GetReplicationConfiguration`, `s3:PutInventoryConfiguration` — bucket-level
+  actions needed by the batch job to read replication config and manage inventory.
+- `s3:InitiateReplication` — object-level action to trigger replication of
+  individual objects.
+
+Usage (after CRR is enabled):
+
+```bash
+aws s3control create-job \
+  --account-id "$ACCOUNT_ID" \
+  --operation '{"S3ReplicateObject":{}}' \
+  --manifest-generator "{
+    \"S3JobManifestGenerator\": {
+      \"ExpectedBucketOwner\": \"${ACCOUNT_ID}\",
+      \"SourceBucket\": \"arn:aws:s3:::${SOURCE_BUCKET}\",
+      \"EnableManifestOutput\": false,
+      \"Filter\": {
+        \"EligibleForReplication\": true,
+        \"ObjectReplicationStatuses\": [\"NONE\", \"FAILED\"]
+      }
+    }
+  }" \
+  --report '{"Enabled":false}' \
+  --priority 1 \
+  --role-arn "arn:aws:iam::${ACCOUNT_ID}:role/s3-batch-replication" \
+  --no-confirmation-required \
+  --region "$REGION"
+```
 
 ## Control Tower VPC Handling
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,9 @@ controls without requiring provider aliases.
   is **deprecated** -- it will be removed in the next major release. See
   [issue #29](https://github.com/infrahouse/terraform-aws-iso27001/issues/29)
   for the migration plan.
+- **S3 Batch Replication Role** -- `s3-batch-replication` IAM role trusted by
+  `batchoperations.s3.amazonaws.com` for running S3 Batch Replication jobs to
+  backfill existing objects when Cross-Region Replication is enabled
 
 ## Quick Start
 

--- a/iam-s3-batch-replication.tf
+++ b/iam-s3-batch-replication.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "s3_batch_replication_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["batchoperations.s3.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "s3_batch_replication_permissions" {
+  statement {
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:PutInventoryConfiguration",
+    ]
+    resources = ["arn:aws:s3:::*"]
+  }
+  statement {
+    actions   = ["s3:InitiateReplication"]
+    resources = ["arn:aws:s3:::*/*"]
+  }
+}
+
+resource "aws_iam_role" "s3_batch_replication" {
+  name               = "s3-batch-replication"
+  assume_role_policy = data.aws_iam_policy_document.s3_batch_replication_trust.json
+}
+
+resource "aws_iam_role_policy" "s3_batch_replication" {
+  name   = "s3-batch-replication"
+  role   = aws_iam_role.s3_batch_replication.name
+  policy = data.aws_iam_policy_document.s3_batch_replication_permissions.json
+}


### PR DESCRIPTION
## Summary

- Adds `s3-batch-replication` IAM role trusted by `batchoperations.s3.amazonaws.com`
- Grants minimum permissions: `s3:GetReplicationConfiguration`, `s3:PutInventoryConfiguration` (bucket-level) and `s3:InitiateReplication` (object-level)
- Updates README, docs/index.md, and docs/architecture.md with the new feature

## Context

When CRR is enabled on a bucket that previously had no versioning, existing objects sit in `NONE` replication status. S3 Batch Replication is needed to backfill them, and it requires this IAM role. Previously hand-created in `aws-control-customer-success`; this PR makes it part of the standard iso27001 deployment for all accounts.

Resolves: INF-1768

## Test plan

- [ ] `terraform validate` passes
- [ ] Role deploys successfully on next iso27001 apply
- [ ] Batch replication job succeeds using this role ARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)